### PR TITLE
Fix crashing due to when hint is not set

### DIFF
--- a/mdetect/src/main/java/me/myatminsoe/mdetect/MMEditText.java
+++ b/mdetect/src/main/java/me/myatminsoe/mdetect/MMEditText.java
@@ -8,28 +8,35 @@ public class MMEditText extends EditText {
 
   public MMEditText(final Context context) {
     super(context);
-    if (MDetect.isUnicode()) {
-      setHint(getHint());
-    } else {
-      setHint(Rabbit.uni2zg(getHint().toString()));
+
+    if (getHint() != null) {
+      if (MDetect.isUnicode()) {
+        setHint(getHint());
+      } else {
+        setHint(Rabbit.uni2zg(getHint().toString()));
+      }
     }
   }
 
   public MMEditText(final Context context, AttributeSet attrs) {
     super(context, attrs);
-    if (MDetect.isUnicode()) {
-      setHint(getHint());
-    } else {
-      setHint(Rabbit.uni2zg(getHint().toString()));
+    if (getHint() != null) {
+      if (MDetect.isUnicode()) {
+        setHint(getHint());
+      } else {
+        setHint(Rabbit.uni2zg(getHint().toString()));
+      }
     }
   }
 
   public MMEditText(final Context context, AttributeSet attrs, int defStyle) {
     super(context, attrs, defStyle);
-    if (MDetect.isUnicode()) {
-      setHint(getHint());
-    } else {
-      setHint(Rabbit.uni2zg(getHint().toString()));
+    if (getHint() != null) {
+      if (MDetect.isUnicode()) {
+        setHint(getHint());
+      } else {
+        setHint(Rabbit.uni2zg(getHint().toString()));
+      }
     }
   }
 


### PR DESCRIPTION
If hint is not set in xml attributes, getHint returns null and thus cause a NullPointerException